### PR TITLE
KAN-32 Feat: enemies and player collision

### DIFF
--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -42,6 +42,14 @@ public class Ship extends Entity {
 	private NumberOfBullet numberOfBullet;
 	/** angle of ship */
 	private double angle;
+	//무적
+	private boolean isInvincible;
+	private long invincibilityStartTime;
+	private static final int INVINCIBILITY_DURATION = 1000;
+
+	private boolean isFrozen;
+	private long frozenStartTime;
+	private static final int FROZEN_DURATION = 1000;
 
 	/**
 	 * Constructor, establishes the ship's properties.
@@ -70,41 +78,67 @@ public class Ship extends Entity {
 		this.destructionCooldown = Core.getCooldown(1000);
 
 		this.numberOfBullet = new NumberOfBullet();
+		this.isInvincible = false;
+		this.invincibilityStartTime = 0;
+		this.isFrozen = false;
+		this.frozenStartTime = 0;
 	}
 
-	/**
-	 * Moves the ship speed uni ts right, or until the right screen border is
-	 * reached.
-	 */
 	public final void moveRight() {
-		this.positionX += growth.getMoveSpeed(); //  Use PlayerGrowth for movement speed
-	} //Edit by Enemy
-
-
-	/**
-	 * Moves the ship speed units left, or until the left screen border is
-	 * reached.
-	 */
+		if (!isFrozen()) {
+			this.positionX += growth.getMoveSpeed();
+		}
+	}
 	public final void moveLeft() {
-		this.positionX -= growth.getMoveSpeed(); // Use PlayerGrowth for movement speed
-	} //Edit by Enemy
-
-	/**
-	 * Moves the ship speed uni ts up, or until the up screen border is
-	 * reached.
-	 */
+		if (!isFrozen()) {
+			this.positionX -= growth.getMoveSpeed();
+		}
+	}
 	public final void moveUp() {
-		this.positionY -= growth.getMoveSpeed(); //  Use PlayerGrowth for movement speed
-	} //Edit by Enemy
+		if (!isFrozen()) {
+			this.positionY -= growth.getMoveSpeed();
+		}
+	}
 
-
-	/**
-	 * Moves the ship speed units down, or until the down screen border is
-	 * reached.
-	 */
 	public final void moveDown() {
-		this.positionY += growth.getMoveSpeed(); // Use PlayerGrowth for movement speed
-	} //Edit by Enemy
+		if (!isFrozen()) {
+			this.positionY += growth.getMoveSpeed();
+		}
+	}
+
+
+	public void activateInvincibility() {
+		this.isInvincible = true;
+		this.invincibilityStartTime = System.currentTimeMillis();
+		System.out.println("Invincibility activated for 3 seconds.");
+	}
+
+	public boolean isInvincible() {
+		if (this.isInvincible) {
+			long elapsed = System.currentTimeMillis() - this.invincibilityStartTime;
+			if (elapsed > INVINCIBILITY_DURATION) {
+				this.isInvincible = false;
+				System.out.println("Invincibility expired.");
+			}
+		}
+		return this.isInvincible;
+	}
+
+	public void activateFrozen() {
+		this.isFrozen = true;
+		this.frozenStartTime = System.currentTimeMillis();
+		System.out.println("Player is frozen for 1 second.");
+	}
+	public boolean isFrozen() {
+		if (this.isFrozen) {
+			long elapsed = System.currentTimeMillis() - this.frozenStartTime;
+			if (elapsed > FROZEN_DURATION) {
+				this.isFrozen = false; // 멈춤 상태 해제
+				System.out.println("Frozen state expired.");
+			}
+		}
+		return this.isFrozen;
+	}
 
 	/**
 	 * Shoots a bullet upwards.
@@ -166,17 +200,17 @@ public class Ship extends Entity {
 
 			// 새롭게 총알을 발사할 x좌표와 y좌표 계산
 			int newheadX = (int) (Math.cos(this.angle) * (headX - centerX)
-                                - Math.sin(this.angle) * (headY - centerY)
-                                + centerX);
+					- Math.sin(this.angle) * (headY - centerY)
+					+ centerX);
 			int newheadY = (int) (Math.sin(this.angle) * (headX - centerX)
-                                + Math.cos(this.angle) * (headY - centerY)
-                                + centerY);
+					+ Math.cos(this.angle) * (headY - centerY)
+					+ centerY);
 
 			// Use NumberOfBullet to generate bullets
 			Set<PiercingBullet> newBullets = numberOfBullet.addBullet(
 					newheadX,
 					newheadY,
-                    (int) (10 * Math.cos(angle)),	// 임시 수치
+					(int) (10 * Math.cos(angle)),	// 임시 수치
 					(int) (10 * Math.sin(angle)),
 					Bomb.getCanShoot(),
 					0,
@@ -262,7 +296,7 @@ public class Ship extends Entity {
 	public final double getSpeed() {
 		return growth.getMoveSpeed();
 	}
-	
+
 	/**
 	 * Calculates and returns the bullet speed in Pixels per frame.
 	 *

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -678,8 +678,55 @@ public class GameScreen extends Screen {
 	 * Manages collisions between bullets and ships. -Edited code for Drop Item
 	 * Manages collisions between bullets and ships. -Edited code for Piercing Bullet
 	 */
-	//by Enemy team
+	private void adjustShipPositionAfterCollision(Ship ship, EnemyShip enemyShip) {
+		int adjustmentDistance = 10; // 충돌 후 벌어질 거리
+
+
+		if (ship.getPositionX() < enemyShip.getPositionX()) {
+			ship.setPositionX(ship.getPositionX() - adjustmentDistance);
+		} else {
+			ship.setPositionX(ship.getPositionX() + adjustmentDistance);
+		}
+
+		if (ship.getPositionY() < enemyShip.getPositionY()) {
+			ship.setPositionY(ship.getPositionY() - adjustmentDistance);
+		} else {
+			ship.setPositionY(ship.getPositionY() + adjustmentDistance);
+		}
+
+		System.out.println("Ship position adjusted to avoid repeated collisions.");
+	}
+
 	public void manageCollisions_add_item() {
+		for (EnemyShip enemyShip : this.enemyShipFormation) {
+			if (!enemyShip.isDestroyed() && checkCollision(this.ship, enemyShip)) {
+				if (this.ship.isInvincible()) {
+					System.out.println("Collision ignored due to invincibility.");
+				} else if (this.item.isbarrierActive()) {
+					this.ship.activateFrozen();
+					adjustShipPositionAfterCollision(this.ship, enemyShip);
+					System.out.println("Collision blocked by shield.");
+
+				} else {
+					System.out.println("Collision detected. Player lives decreased.");
+					if (this.ship.isInvincible()) {
+						System.out.println("Collision ignored due to invincibility.");
+					} else {
+						this.lives--;
+						System.out.println("Collision detected. Player lives decreased.");
+					}
+					this.ship.activateInvincibility();
+					this.ship.destroy();
+					this.logger.info("Player ship collided with enemy. Lives remaining: " + this.lives);
+
+					if (this.lives <= 0) {
+						sm = SoundManager.getInstance();
+						sm.playShipDieSounds();
+						System.out.println("Player is out of lives.");
+					}
+				}
+			}
+		}
 		Set<PiercingBullet> recyclable = new HashSet<PiercingBullet>();
 		for (PiercingBullet bullet : this.bullets)
 			if (bullet.getBulletType() != 0) {


### PR DESCRIPTION
적함선와 플레이어 함선이 충돌하였을 때 베리어가 활성하지 않았으면 생명이 감소하게 했습니다. 
적함선과 충돌하면 반복 충돌 문제를 예방하기 위해 충돌함선과의 거리 조정&경직을 적용했습니다.